### PR TITLE
Modify Known to also incorporate defined-ness conditions for its arguments

### DIFF
--- a/precondition.py
+++ b/precondition.py
@@ -213,11 +213,12 @@ class LLVMBoolPred(BoolPred):
     return mk_and(c)
 
   def toSMT(self, state):
-    args = [v.toSMT([], state, []) for v in self.args]
+    defargs = []
+    args = [v.toSMT(defargs, state, []) for v in self.args]
     return {
       self.isPower2:  lambda a: And(a != 0, a & (a-1) == 0),
       self.isSignBit: lambda a: a == (1 << (a.sort().size()-1)),
-      self.known:     lambda a,b: a == b,
+      self.known:     lambda a,b: mk_and(defargs + [a == b]),
       self.maskZero:  lambda a,b: a & b == 0,
       self.NSWAdd:    lambda a,b: SignExt(1,a)+SignExt(1,b) == SignExt(1, a+b),
     }[self.op](*args)


### PR DESCRIPTION
We have a bug where this optimization was getting a spurious counterexample:

```
Pre: Known(%3, true)

%0 = udiv i32 %a, %b
%1 = icmp ne i32 0, %0
%2 = icmp ne i32 1, %0
%3 = and i1 %1, %2
%4 = icmp eq i32 0, %b
 =>
%0 = udiv i32 %a, %b
%1 = icmp ne i32 0, %0
%2 = icmp ne i32 1, %0
%3 = and i1 %1, %2
%4 = false
```

This happens because `%4` does not directly depend on the preceding instructions, so the requirement `%b != 0` from `%0` is not part of the requirement for `%4`. 

The precondition `Known(%3,true)` creates an indirect dependence on `%0` for `%1`, but also does not incorporate the `%b != 0` requirement.

This patch modifies `Known` to incorporate the requirements for its argument. This resolves the bug, but may introduce redundancies in other optimizations. 

There may be better ways to fix this.
