### PR TITLE
Make abs, lshr, and umax return types match argument types.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -218,10 +218,10 @@ class CnstFunction(Constant):
 
   def getTypeConstraints(self):
     c = {
-      self.abs:   lambda a: allTyEqual([a], Type.Int),
+      self.abs:   lambda a: allTyEqual([a,self], Type.Int),
       self.lshr:  lambda a,b: allTyEqual([a,b,self], Type.Int),
       self.trunc: lambda a: [self.type < a.type],
-      self.umax:  lambda a,b: allTyEqual([a,b], Type.Int),
+      self.umax:  lambda a,b: allTyEqual([a,b,self], Type.Int),
       self.width: lambda a: [],
     }[self.op](*self.args)
 


### PR DESCRIPTION
This potentially reduces unnecessary type variation, and fixes a crash when `lshr(undef,1)` occurred in a precondition.

This prevents certain test cases where `C1` and `C2` have one type, but `umax(C1,C2)` has another, but I don't believe this is an intended feature.
